### PR TITLE
optimistic-ui: fix incorrect cloning

### DIFF
--- a/src/optimisticUi.ts
+++ b/src/optimisticUi.ts
@@ -61,7 +61,10 @@ export function optimisticUi<Domain>(params: Params<Domain>) {
     withPendingTransactions: function(data: Data<Domain>): Data<Domain> {
       if (!optimisticUIEnabled()) return data;
 
-      const result = { ...data };
+      const result: any = {};
+      Object.keys(data).forEach(k => {
+        result[k] = { ...(data as any)[k] };
+      });
 
       // Apply pending transactions on top of the canon version
       pendingTransactions.forEach(function(transaction) {


### PR DESCRIPTION
A mistake in cloning led to incorrect mutations.

Could have prevented with an immutable library, but I don’t want to take on an immutable library as a dependency in oncilla to avoid bloat.

Testing could have helped, but I couldn’t have tests at the initial design stage, and now it’s on the backlog.