### PR TITLE
Generic WebSocket server tooling

### DIFF
--- a/src/network/websockets/memoryServer.ts
+++ b/src/network/websockets/memoryServer.ts
@@ -1,3 +1,5 @@
+import { Server as HttpServer } from "http";
+
 import { Data } from "../../core";
 
 import { runWebsocketServer } from "./server";
@@ -6,11 +8,12 @@ const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
 type Params = {
   data: Data<any>;
-  port: number;
-};
+} & (
+  | { port: number; server?: undefined }
+  | { port?: undefined; server: HttpServer });
 
 export function runMemoryServer(params: Params) {
-  const { data, port } = params;
+  const { data, port, server } = params;
 
   function getItem(kind: string, id: string) {
     const item = data[kind][id];
@@ -30,6 +33,7 @@ export function runMemoryServer(params: Params) {
     onRequestData: function({ kind, id, send }) {
       send(getItem(kind, id));
     },
-    port
+    port: port as any,
+    server: server as any
   });
 }

--- a/src/network/websockets/memoryServer.ts
+++ b/src/network/websockets/memoryServer.ts
@@ -4,7 +4,12 @@ import { runWebsocketServer } from "./server";
 
 const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
-export function runMemoryServer(params: { data: Data<any>; port: number }) {
+type Params = {
+  data: Data<any>;
+  port: number;
+};
+
+export function runMemoryServer(params: Params) {
   const { data, port } = params;
 
   function getItem(kind: string, id: string) {

--- a/src/network/websockets/memoryServer.ts
+++ b/src/network/websockets/memoryServer.ts
@@ -1,6 +1,8 @@
-import NanoEvents from "nanoevents";
-import WebSocket from "ws";
 import { Data } from "../../core";
+
+import { runWebsocketServer } from "./server";
+
+const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
 export function runMemoryServer(params: { data: Data<any>; port: number }) {
   const { data, port } = params;
@@ -11,59 +13,18 @@ export function runMemoryServer(params: { data: Data<any>; port: number }) {
     return item;
   }
 
-  const events = new NanoEvents<{ change: [string, string] }>();
-  function changeItem(kind: string, id: string, value: any) {
-    const curr = getItem(kind, id);
-    curr.revision = String(Number(curr.revision) + 1);
-    curr.value = value;
-    events.emit("change", [kind, id]);
-  }
-
-  const server = new WebSocket.Server({ port });
-
-  server.on("connection", function(socket) {
-    const send = (obj: {}) => {
-      if (socket.readyState !== 1) return;
-      socket.send(JSON.stringify(obj));
-    };
-
-    const sendItem = (kind: string, id: string) => {
-      const t = getItem(kind, id);
-      send({
-        action: "update",
-        id,
-        kind,
-        revision: t.revision,
-        value: t.value
-      });
-    };
-
-    const handlers: { [action: string]: (msg: any) => void } = {
-      ping: () => send({ action: "pong" }),
-      push: msg => {
-        changeItem(msg.kind, msg.id, msg.value);
-        setTimeout(function() {
-          send({
-            action: "pushResult",
-            pushId: msg.pushId,
-            result: "success"
-          });
-        }, 500);
-      },
-      subscribe: msg => {
-        sendItem(msg.kind, msg.id);
-        events.on("change", ([kind, id]) => {
-          if (msg.kind === kind && msg.id === id) sendItem(msg.kind, msg.id);
-        });
-      }
-    };
-
-    socket.on("message", function(incomingBytes) {
-      const msg = JSON.parse(incomingBytes.toString());
-      const action = msg.action;
-      const handler = handlers[action];
-      if (!handler) return console.warn("Unrecognized message", msg);
-      handler(msg);
-    });
+  runWebsocketServer({
+    onChangeData: async function({ kind, id, send, value }) {
+      await wait(500);
+      const curr = getItem(kind, id);
+      curr.revision = String(Number(curr.revision) + 1);
+      curr.value = value;
+      send(curr);
+      return "success";
+    },
+    onRequestData: function({ kind, id, send }) {
+      send(getItem(kind, id));
+    },
+    port
   });
 }

--- a/src/network/websockets/server/index.ts
+++ b/src/network/websockets/server/index.ts
@@ -1,0 +1,91 @@
+import NanoEvents from "nanoevents";
+import WebSocket from "ws";
+
+import { stringy, K, KV, Params, ValueContainer } from "./types";
+
+export function runWebsocketServer(params: Params) {
+  const { onChangeData, onRequestData } = params;
+
+  const events = new NanoEvents<{ change: KV }>();
+
+  const latestCopies: { [stringy: string]: undefined | ValueContainer } = {};
+  events.on("change", kv => {
+    latestCopies[stringy(kv)] = kv.value;
+  });
+
+  const listeningTo: string[] = [];
+  function getAndObserve(k: K, f: (value: ValueContainer) => void) {
+    events.on("change", eventKV => {
+      if (stringy(k) === stringy(eventKV)) f(eventKV.value);
+    });
+    if (listeningTo.includes(stringy(k))) {
+      const last = latestCopies[stringy(k)];
+      if (last) f(last);
+      return;
+    }
+    listeningTo.push(stringy(k));
+    onRequestData({
+      ...k,
+      send: value => events.emit("change", { ...k, value })
+    });
+  }
+
+  const server = new WebSocket.Server({
+    port: params.port,
+    server: params.server
+  });
+
+  server.on("connection", function(socket) {
+    const send = (obj: {}) => {
+      if (socket.readyState !== 1) return;
+      socket.send(JSON.stringify(obj));
+    };
+
+    const handlers: { [action: string]: (msg: any) => void } = {
+      ping: () => send({ action: "pong" }),
+      push: msg => {
+        const { kind, id, value } = msg;
+        onChangeData({
+          kind,
+          id,
+          value,
+          send: v => events.emit("change", { kind, id, value: v })
+        })
+          .then(function(result) {
+            send({
+              action: "pushResult",
+              pushId: msg.pushId,
+              result: result
+            });
+          })
+          .catch(function() {
+            send({
+              action: "pushResult",
+              pushId: msg.pushId,
+              result: "internalError"
+            });
+          });
+      },
+      subscribe: msg => {
+        const { id, kind } = msg;
+        getAndObserve({ kind, id }, v =>
+          send({
+            action: "update",
+            id,
+            kind,
+            revision: v.revision,
+            value: v.value
+          })
+        );
+      }
+    };
+
+    socket.on("message", function(incomingBytes) {
+      const msg = JSON.parse(incomingBytes.toString());
+      const action = msg.action;
+      const handler = handlers[action];
+      if (!handler) return console.warn("Unrecognized message", msg);
+      handler(msg);
+    });
+  });
+}

--- a/src/network/websockets/server/types.ts
+++ b/src/network/websockets/server/types.ts
@@ -1,0 +1,30 @@
+import { Server as HttpServer } from "http";
+
+export const stringy = ({ kind, id }: K) => `${kind}-${id}`;
+
+export type K = {
+  id: string;
+  kind: string;
+};
+
+export type KV = K & {
+  value: ValueContainer;
+};
+
+export type Params = {
+  onChangeData: (params: {
+    kind: string;
+    id: string;
+    send: (v: ValueContainer) => void;
+    value: unknown;
+  }) => Promise<"success" | "conflict">;
+  onRequestData: (params: {
+    kind: string;
+    id: string;
+    send: (v: ValueContainer) => void;
+  }) => void;
+} & (
+  | { port: number; server?: undefined }
+  | { port?: undefined; server: HttpServer });
+
+export type ValueContainer = { revision: string; value: unknown };


### PR DESCRIPTION
This creates an abstract websocket server tooling, and the existing memoryServer is the first user of that. I suggest to review by taking a look at how the new code of memoryServer looks like.

The code in server/ itself is a bit exploratory, so feel free to not delve too deep into it. Ultimately it’s an abstraction over our WebSocket protocol, isolating the parts that matter, the data fetching/pushing parts.