### PR TITLE
Clarifications of setup guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ Install Oncilla DB from npm registry with `npm install --save oncilla`.
 Configure Oncilla DB for your data kinds. Data kinds are synchronized atomically, and in full. For an example, for a to-do app the kinds would be tasks and tags. Configure with empty objects for every key. You also need to provide your instance of React for Oncilla to generate hooks specific to your application.
 
 ```js
-import { configure } from "oncilla";
+import { configure } from "oncilla/dist/react";
 const { create } = configure({
   data: {
     categories: {},

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ Install Oncilla DB from npm registry with `npm install --save oncilla`.
 Configure Oncilla DB for your data kinds. Data kinds are synchronized atomically, and in full. For an example, for a to-do app the kinds would be tasks and tags. Configure with empty objects for every key. You also need to provide your instance of React for Oncilla to generate hooks specific to your application.
 
 ```js
-import { configure } from "oncilla/dist/react";
+import { configure } from "oncilla";
 const { create } = configure({
   data: {
     categories: {},
@@ -42,7 +42,7 @@ Now include your database in the UI. React is the primary way to use Oncilla, bu
 
 ```jsx
 const { withDB } = create({ network: network });
-ReactDOM.render({withDB(<App />)});
+ReactDOM.render(withDB(<App />));
 ```
 
 Now you can use the data access hooks in your components, as shown in the [main readme](../README.md).


### PR DESCRIPTION
Here's two issues I ran into while setting up a sample React project to use oncilla. I saw that the original setup guide had the import set to oncilla vs "oncilla/dist/react", which did not work for me. Also found issues when using curly braces as per the setup guide for line 

`ReactDOM.render({withDB(<App />)});`