### PR TITLE
core/sync: stop sending duplicate subscribe messages

### DIFF
--- a/docs/network/wsProtocol.md
+++ b/docs/network/wsProtocol.md
@@ -60,6 +60,8 @@ The client expresses an intent to receive messages about a particular domain ent
 
 The general expectation of a subscription is that the server will immediately queue sending an `update` message with the current version of the entity, and will keep sending further `update` messages whenever anything changes about this domain entity.
 
+A client must not send a duplicate `subscribe` in the same session.
+
 The server may, however, decide to send fewer update messages than there are updates. (And even more, duplicates are not problematic)
 
 ```json

--- a/src/core/sync/index.ts
+++ b/src/core/sync/index.ts
@@ -9,19 +9,25 @@ function makeCounters() {
   return {
     add: function(a: string, b: string, f: () => () => void) {
       const kind = stringify(a, b);
-      if (!data[kind] || data[kind].count === 0) {
-        data[kind] = { count: 0, cancel: f() };
-      }
-      data[kind].count += 1;
-      return function() {
-        data[kind].count -= 1;
-        if (data[kind].count === 0) {
-          data[kind].cancel();
-          data[kind].cancel = () => {
-            throw new Error(`Assertion error`);
-          };
-        }
-      };
+
+      // Cancellation is still not in the protocol,
+      // so this is stub logic for now that never cancels.
+      if (!data[kind]) data[kind] = { count: 1, cancel: f() };
+      return () => {};
+
+      // if (!data[kind] || data[kind].count === 0) {
+      //   data[kind] = { count: 0, cancel: f() };
+      // }
+      // data[kind].count += 1;
+      // return function() {
+      //   data[kind].count -= 1;
+      //   if (data[kind].count === 0) {
+      //     data[kind].cancel();
+      //     data[kind].cancel = () => {
+      //       throw new Error(`Assertion error`);
+      //     };
+      //   }
+      // };
     }
   };
 }


### PR DESCRIPTION
Disabling this, since server-side cancellation is not ready yet.