### PR TITLE
Convinience Termination Method

### DIFF
--- a/src/network/websockets/server/types.ts
+++ b/src/network/websockets/server/types.ts
@@ -18,12 +18,14 @@ export type Params = {
     kind: string;
     lastSeenRevision: string;
     id: string;
+    close: () => void;
     send: (v: ValueContainer) => void;
     value: unknown;
   }) => Promise<"success" | "conflict">;
   onRequestData: (params: {
     kind: string;
     id: string;
+    close: () => void;
     send: (v: ValueContainer) => void;
   }) => void;
   serialization?: Serialization;


### PR DESCRIPTION
This PR adds a convenience method for web socket servers to terminate connections. Adding this method will allow a client to implement the following sample use case, once authentication is in place:

```
onChangeData: function({ auth, close, kind, id }) {
  if (!idBelongsToUser(kind, id, auth)) return close();
}
```