### PR TITLE
Adding Key to Identify Connections

### DIFF
--- a/sample/src/sample.ts
+++ b/sample/src/sample.ts
@@ -3,16 +3,21 @@ import { Server as HttpServer } from "http";
 
 export function attachWebSockets(server: HttpServer) {
   runWebsocketServer({
-    onAuthenticate: async function(msg: any) {
-      console.log("onAuthenticate: " + JSON.stringify(msg));
+    onAuthenticate: async function({ token, secWSKey }) {
+      console.log("token: " + JSON.stringify(token));
+      console.log("secWSKey: " + secWSKey);
       return "success";
     },
-    onChangeData: async function(msg: any) {
-      console.log("onChangeData: " + JSON.stringify(msg));
+    onChangeData: async function({ kind, id, secWSKey }) {
+      console.log("kind: " + kind);
+      console.log("id: " + id);
+      console.log("secWSKey: " + secWSKey);
       return "success";
     },
-    onRequestData: function(msg: any) {
-      console.log("onRequestData: " + JSON.stringify(msg));
+    onRequestData: function({ kind, id, secWSKey }) {
+      console.log("kind: " + kind);
+      console.log("id: " + id);
+      console.log("secWSKey: " + secWSKey);
     },
     serialization: {
       encode: value => {

--- a/src/network/websockets/server/types.ts
+++ b/src/network/websockets/server/types.ts
@@ -16,6 +16,7 @@ export type KV = K & {
 export type Params = {
   onAuthenticate?: (params: {
     close: () => void;
+    secWSKey: string;
     token: string;
   }) => Promise<"success" | "failure">;
   onChangeData: (params: {
@@ -24,12 +25,14 @@ export type Params = {
     id: string;
     close: () => void;
     send: (v: ValueContainer) => void;
+    secWSKey: string;
     value: unknown;
   }) => Promise<"success" | "conflict">;
   onRequestData: (params: {
     kind: string;
     id: string;
     close: () => void;
+    secWSKey: string;
     send: (v: ValueContainer) => void;
   }) => void;
   serialization?: Serialization;


### PR DESCRIPTION
Adding an identifier to websocket connection. Server can utilize id to correlate messages to same individual. https://tools.ietf.org/html/rfc6455#page-57. 