### PR TITLE
Auth interface proposal in websockets/server

### DIFF
--- a/sample/package.json
+++ b/sample/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@types/koa": "^2.0.48",
     "koa": "^2.7.0",
-    "oncilla": "^2.2.0",
+    "oncilla": "^3.0.0",
     "ts-node": "^8.3.0"
   },
   "engines": {

--- a/sample/src/sample.ts
+++ b/sample/src/sample.ts
@@ -3,9 +3,19 @@ import { Server as HttpServer } from "http";
 
 export function attachWebSockets(server: HttpServer) {
   runWebsocketServer({
-    onAuthenticate: async function(msg: any) {
-      console.log("onAuthenticate: " + JSON.stringify(msg));
-      return "success";
+    auth: {
+      canRead: ({ auth, kind, id }) => {
+        console.log("canRead", auth, kind, id);
+        return true;
+      },
+      canWrite: ({ auth, kind, id }) => {
+        console.log("canWrite", auth, kind, id);
+        return true;
+      },
+      parseToken: async token => {
+        console.log("parseToken", token);
+        return "john";
+      }
     },
     onChangeData: async function(msg: any) {
       console.log("onChangeData: " + JSON.stringify(msg));

--- a/src/network/websockets/memoryServer.ts
+++ b/src/network/websockets/memoryServer.ts
@@ -32,10 +32,6 @@ export function runMemoryServer(params: Params) {
   }
 
   runWebsocketServer({
-    onAuthenticate: async function() {
-      await wait(500);
-      return "success";
-    },
     onChangeData: async function({ kind, id, send, value }) {
       await wait(500);
       const curr = getItem(kind, id);

--- a/src/network/websockets/server/auth.test.ts
+++ b/src/network/websockets/server/auth.test.ts
@@ -1,0 +1,142 @@
+import test from "ava";
+import { runWebsocketServer } from ".";
+import { makeWsMock } from "./ws-mock";
+
+test.cb("websocket server allows to read and write when auth allows", t => {
+  const ws = makeWsMock();
+  runWebsocketServer({
+    auth: {
+      canRead: ({ auth, kind, id }) => {
+        t.is(kind, "tasks");
+        t.is(id, "1");
+        t.is(auth, "john");
+        return true;
+      },
+      canWrite: ({ auth, kind, id }) => {
+        t.is(kind, "tasks");
+        t.is(id, "1");
+        t.is(auth, "john");
+        return true;
+      },
+      parseToken: async token => {
+        t.is(token, "t1");
+        return "john";
+      }
+    },
+    onChangeData: async ({ send, value }) => {
+      send({ revision: "2", value });
+      return "success";
+    },
+    onRequestData: ({ send }) => {
+      send({ revision: "1", value: "Buy milk" });
+    },
+    _ws: ws.server
+  });
+  const client = ws.client(msg => {
+    if (msg.action === "update" && msg.revision === "2") {
+      t.end();
+    }
+  });
+  client.send({ action: "auth", token: "t1" });
+  client.send({ action: "subscribe", kind: "tasks", id: "1" });
+  client.send({
+    action: "push",
+    kind: "tasks",
+    id: "1",
+    lastSeenRevision: "1",
+    value: JSON.stringify("Buy cocoa"),
+    pushId: "p1"
+  });
+});
+
+test.cb("websocket server forbids to read without login", t => {
+  const ws = makeWsMock();
+  runWebsocketServer({
+    auth: {
+      canRead: () => true,
+      canWrite: () => true,
+      parseToken: async () => "john"
+    },
+    onChangeData: async () => "success",
+    onRequestData: ({ send }) => {
+      send({ revision: "1", value: "Buy milk" });
+    },
+    _ws: ws.server
+  });
+  const client = ws.client(msg => {
+    if (msg.action === "update") {
+      t.fail("Should not receive an update, it’s forbidden");
+    }
+  });
+  client.send({ action: "subscribe", kind: "tasks", id: "1" });
+  setTimeout(() => t.end(), 100);
+});
+
+test.cb("websocket server forbids to read when forbidden", t => {
+  const ws = makeWsMock();
+  runWebsocketServer({
+    auth: {
+      canRead: ({ auth, kind, id }) => {
+        t.is(kind, "tasks");
+        t.is(id, "1");
+        t.is(auth, "john");
+        return false;
+      },
+      canWrite: () => true,
+      parseToken: async () => "john"
+    },
+    onChangeData: async () => "success",
+    onRequestData: ({ send }) => {
+      send({ revision: "1", value: "Buy milk" });
+    },
+    _ws: ws.server
+  });
+  const client = ws.client(msg => {
+    if (msg.action === "update") {
+      t.fail("Should not receive an update, it’s forbidden");
+    }
+  });
+  client.send({ action: "auth", token: "t1" });
+  client.send({ action: "subscribe", kind: "tasks", id: "1" });
+  setTimeout(() => t.end(), 100);
+});
+
+test.cb("websocket server forbids to write when forbidden", t => {
+  const ws = makeWsMock();
+  runWebsocketServer({
+    auth: {
+      canRead: () => true,
+      canWrite: ({ auth, kind, id }) => {
+        t.is(kind, "tasks");
+        t.is(id, "1");
+        t.is(auth, "john");
+        return false;
+      },
+      parseToken: async () => "john"
+    },
+    onChangeData: async ({ send, value }) => {
+      send({ revision: "2", value });
+      return "success";
+    },
+    onRequestData: ({ send }) => {
+      send({ revision: "1", value: "Buy milk" });
+    },
+    _ws: ws.server
+  });
+  const client = ws.client(msg => {
+    if (msg.action === "update" && msg.revision === "2") {
+      t.fail("Should not have allowed an update, it’s forbidden");
+    }
+  });
+  client.send({ action: "auth", token: "t1" });
+  client.send({ action: "subscribe", kind: "tasks", id: "1" });
+  client.send({
+    action: "push",
+    kind: "tasks",
+    id: "1",
+    lastSeenRevision: "1",
+    value: JSON.stringify("Buy cocoa"),
+    pushId: "p1"
+  });
+  setTimeout(() => t.end(), 100);
+});

--- a/src/network/websockets/server/index.ts
+++ b/src/network/websockets/server/index.ts
@@ -36,10 +36,12 @@ export function runWebsocketServer(params: Params) {
     });
   }
 
-  const server = new WebSocket.Server({
-    port: params.port,
-    server: params.server
-  });
+  const server =
+    params._ws ||
+    new WebSocket.Server({
+      port: params.port,
+      server: params.server
+    });
 
   server.on("connection", function(socket) {
     const send = (obj: {}) => {

--- a/src/network/websockets/server/sanity.test.ts
+++ b/src/network/websockets/server/sanity.test.ts
@@ -14,3 +14,66 @@ test.cb("websocket server responds to ping", t => {
   });
   client.send({ action: "ping" });
 });
+
+test.cb("websocket server retrieves data", t => {
+  const ws = makeWsMock();
+  runWebsocketServer({
+    onChangeData: async () => "success",
+    onRequestData: ({ id, kind, send }) => {
+      t.is(id, "1");
+      t.is(kind, "tasks");
+      send({ revision: "1", value: "Buy milk" });
+    },
+    _ws: ws.server
+  });
+  const client = ws.client(msg => {
+    if (msg.action === "update") {
+      t.is(msg.kind, "tasks");
+      t.is(msg.id, "1");
+      t.is(msg.revision, "1");
+      t.is(msg.value, JSON.stringify("Buy milk"));
+      t.end();
+    }
+  });
+  client.send({ action: "subscribe", kind: "tasks", id: "1" });
+});
+
+test.cb("websocket server writes data", t => {
+  const ws = makeWsMock();
+  runWebsocketServer({
+    onChangeData: async ({ id, kind, send, value }) => {
+      t.is(id, "1");
+      t.is(kind, "tasks");
+      send({ revision: "2", value });
+      return "success";
+    },
+    onRequestData: ({ send }) => {
+      send({ revision: "1", value: "Buy milk" });
+    },
+    _ws: ws.server
+  });
+  let seenUpdate = false;
+  const client = ws.client(msg => {
+    if (msg.action === "update" && msg.revision === "2") {
+      seenUpdate = true;
+      t.is(msg.kind, "tasks");
+      t.is(msg.id, "1");
+      t.is(msg.value, JSON.stringify("Buy cocoa"));
+    }
+    if (msg.action === "pushResult") {
+      t.true(seenUpdate);
+      t.is(msg.pushId, "p1");
+      t.is(msg.result, "success");
+      t.end();
+    }
+  });
+  client.send({ action: "subscribe", kind: "tasks", id: "1" });
+  client.send({
+    action: "push",
+    kind: "tasks",
+    id: "1",
+    lastSeenRevision: "1",
+    value: JSON.stringify("Buy cocoa"),
+    pushId: "p1"
+  });
+});

--- a/src/network/websockets/server/sanity.test.ts
+++ b/src/network/websockets/server/sanity.test.ts
@@ -1,0 +1,16 @@
+import test from "ava";
+import { runWebsocketServer } from ".";
+import { makeWsMock } from "./ws-mock";
+
+test.cb("websocket server responds to ping", t => {
+  const ws = makeWsMock();
+  runWebsocketServer({
+    onChangeData: async () => "success",
+    onRequestData: () => {},
+    _ws: ws.server
+  });
+  const client = ws.client(msg => {
+    if (msg.action === "pong") t.end();
+  });
+  client.send({ action: "ping" });
+});

--- a/src/network/websockets/server/types.ts
+++ b/src/network/websockets/server/types.ts
@@ -1,5 +1,5 @@
 import { Server as HttpServer } from "http";
-
+import { Server as WsServer } from "ws";
 import { Serialization } from "../serialization";
 
 export const stringy = ({ kind, id }: K) => `${kind}-${id}`;
@@ -34,7 +34,8 @@ export type Params = {
   }) => void;
   serialization?: Serialization;
 } & (
-  | { port: number; server?: undefined }
-  | { port?: undefined; server: HttpServer });
+  | { port: number; server?: undefined; _ws?: undefined }
+  | { port?: undefined; server: HttpServer; _ws?: undefined }
+  | { port?: undefined; server?: undefined; _ws?: WsServer });
 
 export type ValueContainer = { revision: string; value: unknown };

--- a/src/network/websockets/server/types.ts
+++ b/src/network/websockets/server/types.ts
@@ -13,11 +13,20 @@ export type KV = K & {
   value: ValueContainer;
 };
 
-export type Params = {
-  onAuthenticate?: (params: {
-    close: () => void;
-    token: string;
-  }) => Promise<"success" | "failure">;
+export type Params<AuthDetails> = {
+  auth?: {
+    canRead: (params: {
+      auth: AuthDetails;
+      kind: string;
+      id: string;
+    }) => boolean;
+    canWrite: (params: {
+      auth: AuthDetails;
+      kind: string;
+      id: string;
+    }) => boolean;
+    parseToken: (token: string) => Promise<AuthDetails>;
+  };
   onChangeData: (params: {
     kind: string;
     lastSeenRevision: string;

--- a/src/network/websockets/server/ws-mock.ts
+++ b/src/network/websockets/server/ws-mock.ts
@@ -1,0 +1,40 @@
+import { Server } from "ws";
+
+type Message = { action: string; [k: string]: any };
+
+export function makeWsMock() {
+  let connectionListener: (socket: WebSocket) => void;
+  const server: Server = ({
+    on: function(event: string, cb: Function) {
+      if (event === "connection") {
+        if (connectionListener) throw new Error("Not implemented");
+        connectionListener = cb as any;
+        return server;
+      }
+      throw new Error("Not implemented");
+    }
+  } as Partial<Server>) as Server;
+  return {
+    client: (onServerMessage: (msg: Message) => void) => {
+      let onClientMessage: Function;
+      const socket: WebSocket = ({
+        on: function(event: string, cb: Function) {
+          if (event === "message") {
+            if (onClientMessage) throw new Error("Not implemented");
+            onClientMessage = cb as any;
+            return;
+          }
+          throw new Error("Not implemented");
+        },
+        readyState: 1,
+        send: (data: string) => onServerMessage(JSON.parse(data))
+      } as Partial<WebSocket>) as WebSocket;
+      connectionListener(socket);
+      return {
+        send: (msg: Message) =>
+          onClientMessage(Buffer.from(JSON.stringify(msg)))
+      };
+    },
+    server
+  };
+}


### PR DESCRIPTION
First and foremost review the new proposed auth engine in d103711. Here is the core piece:

https://github.com/citrusbyte/oncilla/blob/d103711eed51e0110e7ba4d653cc79ef538083c2/src/network/websockets/server/types.ts#L17-L29

The proposal includes the new authentication functions being clearly separate from data retrieval and write functions. The primary purpose of that is to allow caching in oncilla-server memory, but it also benefits by clearly putting authorization in one place and not allowing to forget to define authorization for one operation of the two.

Because this becomes a more critical piece, I’ve put in the effort to add test tooling for this module, as well as tests for the new functinoality.