### PR TITLE
Auth queue

### DIFF
--- a/src/network/websockets/server/authQueue.test.ts
+++ b/src/network/websockets/server/authQueue.test.ts
@@ -95,7 +95,7 @@ test.cb("websocket server queues messages before the first auth", t => {
   }, 10);
 });
 
-test.cb.failing(
+test.cb(
   "websocket server queues messages before the first auth with instant arrival",
   t => {
     const ws = makeWsMock();

--- a/src/network/websockets/server/authQueue.test.ts
+++ b/src/network/websockets/server/authQueue.test.ts
@@ -1,0 +1,152 @@
+import test from "ava";
+import { runWebsocketServer } from ".";
+import { makeWsMock } from "./ws-mock";
+
+const infinitePromise = new Promise(() => {});
+
+test.cb("websocket server queues message processing behind auth", t => {
+  const ws = makeWsMock();
+  runWebsocketServer({
+    auth: {
+      canRead: () => {
+        t.fail("Supposed to wait for token");
+        return true;
+      },
+      canWrite: () => false,
+      parseToken: () => infinitePromise
+    },
+    onChangeData: async () => "success",
+    onRequestData: ({ send }) => send({ revision: "1", value: "Buy milk" }),
+    _ws: ws.server
+  });
+  const client = ws.client(() => {});
+  client.send({ action: "auth", token: "t1" });
+  client.send({ action: "subscribe", kind: "tasks", id: "1" });
+  setTimeout(t.end, 500);
+});
+
+test.cb("websocket server queues message processing behind second auth", t => {
+  const ws = makeWsMock();
+  runWebsocketServer({
+    auth: {
+      canRead: ({ auth }) => auth === "admin",
+      canWrite: () => false,
+      parseToken: async token => (token === "admin" ? "admin" : infinitePromise)
+    },
+    onChangeData: async () => "success",
+    onRequestData: ({ send }) => send({ revision: "1", value: "Buy milk" }),
+    _ws: ws.server
+  });
+  const client = ws.client(msg => {
+    if (msg.action === "update")
+      t.fail("Should not have received with a garbage token");
+  });
+  client.send({ action: "auth", token: "admin" });
+  client.send({ action: "auth", token: "garbage" });
+  client.send({ action: "subscribe", kind: "tasks", id: "1" });
+  setTimeout(t.end, 500);
+});
+
+test.cb("websocket server checks latest permissions for updates", t => {
+  const ws = makeWsMock();
+  runWebsocketServer({
+    auth: {
+      canRead: ({ auth }) => auth === "admin",
+      canWrite: () => false,
+      parseToken: async token => token
+    },
+    onChangeData: async () => "success",
+    onRequestData: ({ send }) => {
+      send({ revision: "1", value: "Buy milk" });
+      setTimeout(() => {
+        send({ revision: "2", value: "Buy milk and eggs" });
+      }, 200);
+    },
+    _ws: ws.server
+  });
+  const client = ws.client(msg => {
+    if (msg.action === "update" && msg.revision === "2")
+      t.fail("Should not have received with a garbage token");
+  });
+  client.send({ action: "auth", token: "admin" });
+  client.send({ action: "subscribe", kind: "tasks", id: "1" });
+  client.send({ action: "auth", token: "garbage" });
+  setTimeout(t.end, 500);
+});
+
+test.cb("websocket server queues messages before the first auth", t => {
+  const ws = makeWsMock();
+  runWebsocketServer({
+    auth: {
+      canRead: ({ auth }) => auth === "admin",
+      canWrite: () => false,
+      parseToken: async token => token
+    },
+    onChangeData: async () => "success",
+    onRequestData: ({ send }) => send({ revision: "1", value: "Buy milk" }),
+    _ws: ws.server
+  });
+  const client = ws.client(msg => {
+    if (msg.action === "update" && msg.revision === "1") t.end();
+  });
+  client.send({ action: "subscribe", kind: "tasks", id: "1" });
+  setTimeout(function() {
+    client.send({ action: "auth", token: "admin" });
+  }, 10);
+});
+
+test.cb.failing(
+  "websocket server queues messages before the first auth with instant arrival",
+  t => {
+    const ws = makeWsMock();
+    runWebsocketServer({
+      auth: {
+        canRead: ({ auth }) => auth === "admin",
+        canWrite: () => false,
+        parseToken: async token => token
+      },
+      onChangeData: async () => "success",
+      onRequestData: ({ send }) => send({ revision: "1", value: "Buy milk" }),
+      _ws: ws.server
+    });
+    const client = ws.client(msg => {
+      if (msg.action === "update" && msg.revision === "1") t.end();
+    });
+    client.send({ action: "subscribe", kind: "tasks", id: "1" });
+    client.send({ action: "auth", token: "admin" });
+  }
+);
+
+test.cb(
+  "websocket server queues messages before the first auth successful auth",
+  t => {
+    const ws = makeWsMock();
+    runWebsocketServer({
+      auth: {
+        canRead: () => false,
+        canWrite: ({ auth }) => auth === "admin",
+        parseToken: async token => (token === "admin" ? "admin" : undefined)
+      },
+      onChangeData: async ({ value }) => {
+        t.is(value, "Buy cocoa");
+        t.end();
+        return "success";
+      },
+      onRequestData: () => {},
+      _ws: ws.server
+    });
+    const client = ws.client(() => {});
+    client.send({ action: "auth", token: "garbage" });
+    client.send({
+      action: "push",
+      kind: "tasks",
+      id: "1",
+      lastSeenRevision: "1",
+      value: JSON.stringify("Buy cocoa"),
+      pushId: "p1"
+    });
+    setTimeout(function() {
+      client.send({ action: "auth", token: "admin" });
+    }, 10);
+  }
+);

--- a/src/network/websockets/server/authQueue.ts
+++ b/src/network/websockets/server/authQueue.ts
@@ -1,39 +1,26 @@
-export function makeAuthQueue<AuthDetails>(params: {
-  onTerminate: () => void;
-}) {
+export function makeAuthQueue<Details>(params: { onTerminate: () => void }) {
   const { onTerminate } = params;
 
-  let authDetails: Promise<AuthDetails | undefined> = Promise.resolve(
-    undefined
-  );
-  let preAuthMessageQueue: (() => void)[] = [];
-
-  const processQueue = () => {
-    preAuthMessageQueue.forEach(f => f());
-    preAuthMessageQueue = [];
-  };
-
-  const addToQueue = (msg: any) => {
-    if (preAuthMessageQueue.length > 100) {
-      console.warn("Cache Size exceeded maximum allowed length");
-      onTerminate();
-      return;
-    }
-    preAuthMessageQueue.push(msg);
-  };
+  let currentPromise: Promise<Details | undefined> = Promise.resolve(undefined);
+  const waitingCalls: ((details: Details) => void)[] = [];
 
   return {
-    details: async (): Promise<AuthDetails> => {
-      let details: AuthDetails | undefined;
-      while (!details) {
-        details = await authDetails;
-        if (!details) await new Promise(addToQueue);
+    details: async (): Promise<Details> => {
+      const details = await currentPromise;
+      if (details) return details;
+      if (waitingCalls.length > 100) {
+        console.warn("Cache Size exceeded maximum allowed length");
+        onTerminate();
+        return new Promise(() => {});
       }
-      return details;
+      return new Promise(resolve => waitingCalls.push(resolve));
     },
-    newAuthIncoming: async (p: Promise<AuthDetails | undefined>) => {
-      authDetails = p;
-      processQueue();
+    newAuthIncoming: async (p: Promise<Details | undefined>) => {
+      currentPromise = p;
+      const details = await p;
+      if (!details || currentPromise !== p) return;
+      waitingCalls.forEach(f => f(details));
+      waitingCalls.splice(0);
     }
   };
 }

--- a/src/network/websockets/server/authQueue.ts
+++ b/src/network/websockets/server/authQueue.ts
@@ -1,0 +1,39 @@
+export function makeAuthQueue<AuthDetails>(params: {
+  onTerminate: () => void;
+}) {
+  const { onTerminate } = params;
+
+  let authDetails: Promise<AuthDetails | undefined> = Promise.resolve(
+    undefined
+  );
+  let preAuthMessageQueue: (() => void)[] = [];
+
+  const processQueue = () => {
+    preAuthMessageQueue.forEach(f => f());
+    preAuthMessageQueue = [];
+  };
+
+  const addToQueue = (msg: any) => {
+    if (preAuthMessageQueue.length > 100) {
+      console.warn("Cache Size exceeded maximum allowed length");
+      onTerminate();
+      return;
+    }
+    preAuthMessageQueue.push(msg);
+  };
+
+  return {
+    details: async (): Promise<AuthDetails> => {
+      let details: AuthDetails | undefined;
+      while (!details) {
+        details = await authDetails;
+        if (!details) await new Promise(addToQueue);
+      }
+      return details;
+    },
+    newAuthIncoming: async (p: Promise<AuthDetails | undefined>) => {
+      authDetails = p;
+      processQueue();
+    }
+  };
+}


### PR DESCRIPTION
This adds tests for our auth queues, combines and extracts them into a separate module.

I advise to review by commit – you’ll see refactoring, tests, and new implementation separately, which helps make sense.

Tests are a bit verbose, looking forward to some more tooling to make them shorter.