### PR TITLE
Resend on reconnect

### DIFF
--- a/src/network/websockets/index.ts
+++ b/src/network/websockets/index.ts
@@ -5,6 +5,7 @@ import { Serialization, jsonSerialization } from "./serialization";
 type Params = {
   serialization?: Serialization;
   url: string;
+  _socket?: ReconnectingWebSocket;
 };
 
 export * from "./memoryServer";
@@ -13,9 +14,9 @@ export { runWebsocketServer } from "./server";
 export function makeWsProtocolAdapter(
   params: Params
 ): { adapter: NetworkAdapter<any>; auth: (token: string) => void } {
-  const { url } = params;
+  const { url, _socket } = params;
   const serialization = params.serialization || jsonSerialization;
-  const socket = new ReconnectingWebSocket(url);
+  const socket = _socket || new ReconnectingWebSocket(url);
 
   let pingTimer: NodeJS.Timer;
   let timeoutTimer: NodeJS.Timer;

--- a/src/network/websockets/index.ts
+++ b/src/network/websockets/index.ts
@@ -34,7 +34,7 @@ export function makeWsProtocolAdapter(
     socket.send(JSON.stringify(input));
   };
 
-  const messagesOnEveryReconnect: object[] = [];
+  const messagesOnEveryReconnect: { [k: string]: any }[] = [];
 
   return {
     adapter: function({
@@ -95,6 +95,14 @@ export function makeWsProtocolAdapter(
         }
       };
     },
-    auth: token => send({ action: "auth", token })
+    auth: token => {
+      const msg = { action: "auth", token };
+      const currentIndex = messagesOnEveryReconnect.findIndex(
+        m => m.action === "auth"
+      );
+      if (currentIndex === -1) messagesOnEveryReconnect.push(msg);
+      else messagesOnEveryReconnect[currentIndex] = msg;
+      if (socket.readyState === 1) send(msg);
+    }
   };
 }

--- a/src/network/websockets/sanity.test.ts
+++ b/src/network/websockets/sanity.test.ts
@@ -7,3 +7,17 @@ test("ws adapter sends subscribe message", t => {
   adapter.getAndObserve("tasks", "1");
   t.true(sentMessages.some(msg => msg.action === "subscribe"));
 });
+
+test("ws adapter resends subscribe message on reconnect", t => {
+  const { adapter, connect, disconnect, sentMessages } = testWsAdapter();
+  connect();
+  adapter.getAndObserve("tasks", "1");
+  const subscribesBefore = sentMessages.filter(
+    msg => msg.action === "subscribe"
+  ).length;
+  disconnect();
+  connect();
+  const subscribesAfter = sentMessages.filter(msg => msg.action === "subscribe")
+    .length;
+  t.true(subscribesAfter > subscribesBefore);
+});

--- a/src/network/websockets/sanity.test.ts
+++ b/src/network/websockets/sanity.test.ts
@@ -21,3 +21,16 @@ test("ws adapter resends subscribe message on reconnect", t => {
     .length;
   t.true(subscribesAfter > subscribesBefore);
 });
+
+test("ws adapter resends one auth message on reconnect", t => {
+  const { auth, connect, disconnect, sentMessages } = testWsAdapter();
+  connect();
+  auth("token-1");
+  auth("token-2");
+  auth("token-3");
+  disconnect();
+  const authsBefore = sentMessages.filter(msg => msg.action === "auth").length;
+  connect();
+  const authsAfter = sentMessages.filter(msg => msg.action === "auth").length;
+  t.is(authsAfter, authsBefore + 1);
+});

--- a/src/network/websockets/sanity.test.ts
+++ b/src/network/websockets/sanity.test.ts
@@ -1,0 +1,9 @@
+import test from "ava";
+import testWsAdapter from "./testWsAdapter";
+
+test("ws adapter sends subscribe message", t => {
+  const { adapter, connect, sentMessages } = testWsAdapter();
+  connect();
+  adapter.getAndObserve("tasks", "1");
+  t.true(sentMessages.some(msg => msg.action === "subscribe"));
+});

--- a/src/network/websockets/testWsAdapter.ts
+++ b/src/network/websockets/testWsAdapter.ts
@@ -1,0 +1,34 @@
+import { makeWsProtocolAdapter } from ".";
+import ReconnectingWebSocket from "reconnecting-websocket";
+
+export default function testWsAdapter() {
+  const sentMessages: { action: string; [k: string]: any }[] = [];
+  const partialSocket: Partial<ReconnectingWebSocket> = {
+    send: data => {
+      sentMessages.push(JSON.parse(String(data)));
+    }
+  };
+  const socket = partialSocket as ReconnectingWebSocket;
+  const sock = socket as any;
+  const adapter = makeWsProtocolAdapter({
+    url: "",
+    _socket: socket
+  }).adapter({
+    onChange: () => {},
+    onConnectivityChange: () => {},
+    onError: () => {},
+    onPushResult: () => {}
+  });
+  return {
+    adapter,
+    disconnect: () => {
+      socket.onclose!({} as any);
+      sock.readyState = 0;
+    },
+    connect: () => {
+      socket.onopen!({} as any);
+      sock.readyState = 1;
+    },
+    sentMessages
+  };
+}

--- a/src/network/websockets/testWsAdapter.ts
+++ b/src/network/websockets/testWsAdapter.ts
@@ -10,10 +10,11 @@ export default function testWsAdapter() {
   };
   const socket = partialSocket as ReconnectingWebSocket;
   const sock = socket as any;
-  const adapter = makeWsProtocolAdapter({
+  const wsp = makeWsProtocolAdapter({
     url: "",
     _socket: socket
-  }).adapter({
+  });
+  const adapter = wsp.adapter({
     onChange: () => {},
     onConnectivityChange: () => {},
     onError: () => {},
@@ -21,6 +22,7 @@ export default function testWsAdapter() {
   });
   return {
     adapter,
+    auth: wsp.auth,
     disconnect: () => {
       socket.onclose!({} as any);
       sock.readyState = 0;


### PR DESCRIPTION
This was a cause of one of our bugs. Our sockets are stateful, but when reconnecting-websocket reconnects, it loses that state: from the point of view of the server it’s a new socket. This tries to maintain a list of messages that encode the current state of the socket and resends them on every reconnect.

