### PR TITLE
Client error

### DIFF
--- a/docs/network/wsProtocol.md
+++ b/docs/network/wsProtocol.md
@@ -135,6 +135,17 @@ The server may respond with an `authResult` message:
 
 Oncilla is indifferent to both the authentication mechanism and value contained in the field, leaving the verification up to the server implementation. A good example of a payload of `token` is a [JWT token](https://jwt.io/).
 
+## Errors
+
+The server may choose to provide a debugging message to the client. This message is meant for developers, and UI apps should probably crash with a user-friendly message.
+
+```json
+{
+  "type": "clientError",
+  "message": "Incorrect call to foo"
+}
+```
+
 ## Limitations
 
 Lost WebSocket messages are not handled in this version.

--- a/src/core/create.ts
+++ b/src/core/create.ts
@@ -8,7 +8,12 @@ const globalWindow = typeof window === "undefined" ? ({} as Window) : window;
 export function create<Domain>(
   params: CreateParams<Domain> & { initialData: Data<Domain> }
 ): FullDB<Domain> {
-  const { initialData, network, onError } = params;
+  const { initialData, network } = params;
+  const onError =
+    params.onError ||
+    (err => {
+      throw err;
+    });
   const window = params.window || globalWindow;
 
   const debugConfig: DebugConfig = {
@@ -26,6 +31,7 @@ export function create<Domain>(
     network,
     onChange: (kind, id) => events.emit("change", [kind, id]),
     onConnectivityChange: () => events.emit("connectivity-changed", undefined),
+    onError,
     shouldCrashWrites: () => debugConfig.failingWrites
   });
 
@@ -37,11 +43,7 @@ export function create<Domain>(
     commitTransaction: push,
     onChangePendingTransactionCount: () =>
       events.emit("pending-transaction-count-changed", undefined),
-    onError:
-      onError ||
-      (err => {
-        throw err;
-      }),
+    onError,
     onRerenderKind: (kind, id) => events.emit("change", [kind, id]),
     optimisticUIEnabled: () => debugConfig.optimisticUIEnabled
   });

--- a/src/core/sync/index.ts
+++ b/src/core/sync/index.ts
@@ -38,6 +38,7 @@ type Params<Domain> = {
   network: NetworkAdapter<Domain>;
   onChange: (kind: keyof Domain, id: string) => void;
   onConnectivityChange: () => void;
+  onError: (err: Error) => void;
   shouldCrashWrites: () => boolean;
 };
 
@@ -47,6 +48,7 @@ export function sync<Domain>(params: Params<Domain>) {
     network,
     onChange,
     onConnectivityChange,
+    onError,
     shouldCrashWrites
   } = params;
 
@@ -67,9 +69,7 @@ export function sync<Domain>(params: Params<Domain>) {
       onChange(kind, id);
     },
     onConnectivityChange: setConnectivity,
-    onError: function(error) {
-      throw error;
-    },
+    onError,
     onPushResult: (pushId, result) => {
       if (!pushesInFlight[pushId]) return;
       pushesInFlight[pushId](result);

--- a/src/network/websockets/index.ts
+++ b/src/network/websockets/index.ts
@@ -50,6 +50,9 @@ export function makeWsProtocolAdapter(
         );
 
       const handlers: { [action: string]: (msg: any) => void } = {
+        clientError: (msg: any) => {
+          onError(new Error(msg.message));
+        },
         pong: () => {},
         pushResult: (msg: any) => onPushResult(msg.pushId, msg.result),
         update: (msg: any) =>

--- a/src/network/websockets/server/index.ts
+++ b/src/network/websockets/server/index.ts
@@ -69,7 +69,13 @@ export function runWebsocketServer<AuthDetails>(params: Params<AuthDetails>) {
         const { kind, id, lastSeenRevision, value } = msg;
         if (auth) {
           const details = await authQueue.details();
-          if (!auth.canWrite({ auth: details, kind, id })) return;
+          if (!auth.canWrite({ auth: details, kind, id })) {
+            send({
+              action: "clientError",
+              message: `Tried to write ${kind} ${id} without permission`
+            });
+            return;
+          }
         }
         onChangeData({
           kind,
@@ -102,7 +108,13 @@ export function runWebsocketServer<AuthDetails>(params: Params<AuthDetails>) {
           async v => {
             if (auth) {
               const details = await authQueue.details();
-              if (!auth.canRead({ auth: details, kind, id })) return;
+              if (!auth.canRead({ auth: details, kind, id })) {
+                send({
+                  action: "clientError",
+                  message: `Tried to read ${kind} ${id} without permission`
+                });
+                return;
+              }
             }
             send({
               action: "update",


### PR DESCRIPTION
The new clientError message helps debug client applications. If the server knows there is a bug on the client, it can now report it and the client can do something meaningful, like crash with a user-friendly message to avoid corrupted app behavior.