### PR TITLE
network/websockets: when parseToken crashes, close the client

### DIFF
--- a/src/network/websockets/server/index.ts
+++ b/src/network/websockets/server/index.ts
@@ -62,7 +62,10 @@ export function runWebsocketServer<AuthDetails>(params: Params<AuthDetails>) {
         authQueue.newAuthIncoming(
           auth
             .parseToken(token, { close: () => socket.terminate() })
-            .catch(() => undefined)
+            .catch(() => {
+              socket.terminate();
+              return undefined;
+            })
         );
       },
       push: async msg => {


### PR DESCRIPTION
For authorization, if the server’s parseToken crashes, we should assume the user is not authorized. The simplest problematic case is when all users can read things as long as they are authenticated. This will expose the data if the parseToken crashes:

```ts
canRead: () => true,
parseToken: decodeSignedToken,
```