### PR TITLE
websockets: pushResult now has an inline update

### DIFF
--- a/docs/network/README.md
+++ b/docs/network/README.md
@@ -51,10 +51,10 @@ runWebsocketServer({
       throw err;
     }
 
-    // It is important to send an updated value before returning success,
-    // otherwise the UI will display the previous version.
-    send(curr);
-    return "success";
+    return {
+      newRevision: curr.revision,
+      newValue: curr.value
+    };
   },
   onRequestData: async function({ kind, id, send }) {
     // getItem is your function that returns { revision, value } object

--- a/docs/network/wsProtocol.md
+++ b/docs/network/wsProtocol.md
@@ -95,23 +95,25 @@ Upon receiving a push message, the server should validate whether the lastSeenRe
 
 If the lastSeenRevision is valid, the server should save the new revision of the entity.
 
-To be able to provide optimistic UI updates with real-time server-side updates, the client needs to know when a particular push has been accepted by the server. In order to do that, for every received push message the server must send a `pushResult` message to the client with `pushId` and `result` fields.
+To be able to provide optimistic UI updates with real-time server-side updates, the client needs to know when a particular push has been accepted by the server. In order to do that, for every received push message the server must send a `pushResult` message to the client with `pushId`, `result`, and possibly `newRevision` and `newValue` fields.
 
 **pushId** A verbatim string copy of the field in the client’s push message.
 
 **result** If the write succeeded the `result` field must be `"success"`, if the write was rejected because lastSeenRevision was out of date, the field must be `"conflict"`, and if the write was rejected because of internal errors, the field must be `"internalError"`.
 
+**newRevision** If the write succeeded the `newRevision` contains the newest revision number of the entity.
+
+**newValue** If the write succeeded the `newValue` contains the newest value of the entity.
+
 ```json
 {
   "action": "pushResult",
   "pushId": "",
-  "result": "success"
+  "result": "success",
+  "newRevision": "2",
+  "newValue": {}
 }
 ```
-
-A successful push operation will usually result in two messages from the server to the client: an `update` message with the newly updated entity, and a `pushResult` message with the success status of the push. The server must send the update message containing the pushed changed before sending a `pushResult` message.
-
-If the server staggers the update messages, it is fine to send the update message including more changes that the latest push, but it must still be sent before the pushResult message. If necessary, the server may artificially delay the `pushResult` message on the server for up to 5-10 seconds.
 
 ## Authentication
 

--- a/sample/package.json
+++ b/sample/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@types/koa": "^2.0.48",
     "koa": "^2.7.0",
-    "oncilla": "^4.0.0",
+    "oncilla": "^5.0.0",
     "ts-node": "^8.3.0"
   },
   "engines": {

--- a/sample/src/sample.ts
+++ b/sample/src/sample.ts
@@ -19,7 +19,10 @@ export function attachWebSockets(server: HttpServer) {
     },
     onChangeData: async function(msg: any) {
       console.log("onChangeData: " + JSON.stringify(msg));
-      return "success";
+      return {
+        newRevision: "",
+        newValue: {}
+      };
     },
     onRequestData: function(msg: any) {
       console.log("onRequestData: " + JSON.stringify(msg));

--- a/src/core/sync/index.ts
+++ b/src/core/sync/index.ts
@@ -58,7 +58,7 @@ export function sync<Domain>(params: Params<Domain>) {
   }
 
   const pushesInFlight: {
-    [id: string]: (result: PushResult) => void;
+    [id: string]: (result: PushResult<any>) => void;
   } = {};
 
   const net = network({
@@ -84,10 +84,16 @@ export function sync<Domain>(params: Params<Domain>) {
       throw err;
     },
     onNetPush: params =>
-      new Promise(resolve => {
+      new Promise<PushResult<Domain[any]>>(resolve => {
         pushesInFlight[params.pushId] = resolve;
         net.push(params);
       }),
+    onUpdate: ({ kind, id, newValue, newRevision }) => {
+      canonData[kind][id] = {
+        revision: newRevision,
+        value: newValue
+      };
+    },
     shouldCrashWrites
   });
 

--- a/src/network/dummy.ts
+++ b/src/network/dummy.ts
@@ -46,7 +46,7 @@ export function makeDummyAdapter<Domain>(
         setTimeout(() => {
           data[kind][id] = value;
           onChange({ kind, id, revision: "dummy", value });
-          onPushResult(pushId, "success");
+          onPushResult(pushId, { newRevision: "dummy", newValue: value });
           locked = false;
         }, 2000);
       }

--- a/src/network/types.ts
+++ b/src/network/types.ts
@@ -9,7 +9,10 @@ export type NetworkAdapter<Domain> = (params: {
   }) => void;
   onConnectivityChange: (value: Connectivity) => void;
   onError: (error: Error) => void;
-  onPushResult: (pushId: string, result: PushResult) => void;
+  onPushResult: <K extends keyof Domain>(
+    pushId: string,
+    result: PushResult<Domain[K]>
+  ) => void;
 }) => {
   getAndObserve: <K extends keyof Domain>(kind: K, id: string) => () => void;
   push: <K extends keyof Domain>(params: {
@@ -21,4 +24,7 @@ export type NetworkAdapter<Domain> = (params: {
   }) => void;
 };
 
-export type PushResult = "success" | "conflict" | "internalError";
+export type PushResult<Kind> =
+  | { newRevision: string; newValue: Kind }
+  | "conflict"
+  | "internalError";

--- a/src/network/websockets/index.ts
+++ b/src/network/websockets/index.ts
@@ -51,7 +51,14 @@ export function makeWsProtocolAdapter(
 
       const handlers: { [action: string]: (msg: any) => void } = {
         pong: () => {},
-        pushResult: (msg: any) => onPushResult(msg.pushId, msg.result),
+        pushResult: (msg: any) => {
+          if (msg.result === "success")
+            onPushResult(msg.pushId, {
+              newRevision: msg.newRevision,
+              newValue: serialization.decode(msg.newValue)
+            });
+          else onPushResult(msg.pushId, msg.result);
+        },
         update: (msg: any) =>
           onChange({
             kind: msg.kind,

--- a/src/network/websockets/memoryServer.ts
+++ b/src/network/websockets/memoryServer.ts
@@ -32,13 +32,12 @@ export function runMemoryServer(params: Params) {
   }
 
   runWebsocketServer({
-    onChangeData: async function({ kind, id, send, value }) {
+    onChangeData: async function({ kind, id, value }) {
       await wait(500);
       const curr = getItem(kind, id);
       curr.revision = String(Number(curr.revision) + 1);
       curr.value = value;
-      send(curr);
-      return "success";
+      return { newRevision: curr.revision, newValue: curr.value };
     },
     onRequestData: function({ kind, id, send }) {
       send(getItem(kind, id));

--- a/src/network/websockets/server/auth.test.ts
+++ b/src/network/websockets/server/auth.test.ts
@@ -23,17 +23,14 @@ test.cb("websocket server allows to read and write when auth allows", t => {
         return "john";
       }
     },
-    onChangeData: async ({ send, value }) => {
-      send({ revision: "2", value });
-      return "success";
-    },
+    onChangeData: async ({ value }) => ({ newRevision: "2", newValue: value }),
     onRequestData: ({ send }) => {
       send({ revision: "1", value: "Buy milk" });
     },
     _ws: ws.server
   });
   const client = ws.client(msg => {
-    if (msg.action === "update" && msg.revision === "2") {
+    if (msg.action === "pushResult" && msg.newRevision === "2") {
       t.end();
     }
   });
@@ -57,7 +54,7 @@ test.cb("websocket server forbids to read without login", t => {
       canWrite: () => true,
       parseToken: async () => "john"
     },
-    onChangeData: async () => "success",
+    onChangeData: async () => ({ newValue: {}, newRevision: "2" }),
     onRequestData: ({ send }) => {
       send({ revision: "1", value: "Buy milk" });
     },
@@ -85,7 +82,7 @@ test.cb("websocket server forbids to read when forbidden", t => {
       canWrite: () => true,
       parseToken: async () => "john"
     },
-    onChangeData: async () => "success",
+    onChangeData: async () => ({ newValue: {}, newRevision: "2" }),
     onRequestData: ({ send }) => {
       send({ revision: "1", value: "Buy milk" });
     },
@@ -114,17 +111,14 @@ test.cb("websocket server forbids to write when forbidden", t => {
       },
       parseToken: async () => "john"
     },
-    onChangeData: async ({ send, value }) => {
-      send({ revision: "2", value });
-      return "success";
-    },
+    onChangeData: async ({ value }) => ({ newValue: value, newRevision: "2" }),
     onRequestData: ({ send }) => {
       send({ revision: "1", value: "Buy milk" });
     },
     _ws: ws.server
   });
   const client = ws.client(msg => {
-    if (msg.action === "update" && msg.revision === "2") {
+    if (msg.action === "pushResult" && msg.newRevision === "2") {
       t.fail("Should not have allowed an update, it’s forbidden");
     }
   });

--- a/src/network/websockets/server/index.ts
+++ b/src/network/websockets/server/index.ts
@@ -76,15 +76,23 @@ export function runWebsocketServer<AuthDetails>(params: Params<AuthDetails>) {
           lastSeenRevision,
           id,
           value: serialization.decode(value),
-          close: () => socket.terminate(),
-          send: v => events.emit("change", { kind, id, value: v })
+          close: () => socket.terminate()
         })
           .then(function(result) {
-            send({
-              action: "pushResult",
-              pushId: msg.pushId,
-              result: result
-            });
+            if (result === "conflict")
+              send({
+                action: "pushResult",
+                pushId: msg.pushId,
+                result: result
+              });
+            else
+              send({
+                action: "pushResult",
+                pushId: msg.pushId,
+                result: "success",
+                newRevision: result.newRevision,
+                newValue: serialization.encode(result.newValue)
+              });
           })
           .catch(function() {
             send({

--- a/src/network/websockets/server/types.ts
+++ b/src/network/websockets/server/types.ts
@@ -37,9 +37,8 @@ export type Params<AuthDetails> = {
     lastSeenRevision: string;
     id: string;
     close: () => void;
-    send: (v: ValueContainer) => void;
     value: unknown;
-  }) => Promise<"success" | "conflict">;
+  }) => Promise<{ newValue: unknown; newRevision: string } | "conflict">;
   onRequestData: (params: {
     kind: string;
     id: string;


### PR DESCRIPTION
As much as I have tried to keep the server simpler and not rely on atomic update with the push result, it seemed prohibitively complex.

This falls back to making the server save the changes and send the update in one operation.

This is a backwards-breaking change, so here comes Oncilla 5.0! :-)