### PR TITLE
First class transactions

### DIFF
--- a/src/core/create.ts
+++ b/src/core/create.ts
@@ -1,7 +1,14 @@
 import NanoEvents from "nanoevents";
 import { optimisticUi } from "./optimisticUi";
 import { sync } from "./sync";
-import { CreateParams, Data, DebugConfig, FullDB, Events } from "./types";
+import {
+  CreateParams,
+  Data,
+  DebugConfig,
+  FullDB,
+  Events,
+  Transaction
+} from "./types";
 
 const globalWindow = typeof window === "undefined" ? ({} as Window) : window;
 
@@ -36,8 +43,8 @@ export function create<Domain>(
   });
 
   const {
+    addTransaction,
     pendingTransactionCount,
-    update,
     withPendingTransactions
   } = optimisticUi<Domain>({
     commitTransaction: push,
@@ -67,7 +74,9 @@ export function create<Domain>(
     connectivity: () =>
       debugConfig.pretendOffline ? "offline" : connectivity(),
     observe,
-    update
+    update: function(kind, id, delta) {
+      addTransaction({ kind, id, delta } as Transaction<any, any>);
+    }
   };
 
   return db;

--- a/src/core/sync/push.ts
+++ b/src/core/sync/push.ts
@@ -1,5 +1,5 @@
 import { PushResult } from "../../network/types";
-import { Data } from "../types";
+import { Data, Transaction } from "../types";
 import { makeThrottled } from "./throttled";
 
 const defaultRetries = 15;
@@ -136,11 +136,8 @@ export function makePush<Domain>(params: Params<Domain>) {
   }
 
   const run = makeThrottled<keyof Domain>(performPush);
-  return function<K extends keyof Domain>(
-    kind: K,
-    id: string,
-    delta: (prev: Domain[K]) => Domain[K]
-  ) {
+  return function(transaction: Transaction<Domain>) {
+    const { kind, id, delta } = transaction;
     return new Promise<void>(resolve => {
       queuedTasksFor(kind, id).push({ delta, resolve });
       run(kind, id);

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -46,3 +46,9 @@ export type Events<Domain> = {
   "pending-transaction-count-changed": undefined;
   "connectivity-changed": undefined;
 };
+
+export type Transaction<Domain, K extends keyof Domain = keyof Domain> = {
+  kind: K;
+  id: string;
+  delta: Delta<Domain, K>;
+};


### PR DESCRIPTION
With the upcoming creation changes it became inconvenient that we pas around kind/id/delta tuples and manually type them every time. This standardizes a Transaction type and uses it everywhere we used these tuples before.

This is a purely non-functional refactoring.