### PR TITLE
network/websockets/server: clean memory

### DIFF
--- a/src/network/websockets/server/ws-mock.ts
+++ b/src/network/websockets/server/ws-mock.ts
@@ -5,6 +5,7 @@ type Message = { action: string; [k: string]: any };
 export function makeWsMock() {
   let connectionListener: (socket: WebSocket) => void;
   const server: Server = ({
+    clients: new Set(),
     on: function(event: string, cb: Function) {
       if (event === "connection") {
         if (connectionListener) throw new Error("Not implemented");

--- a/src/network/websockets/server/ws-mock.ts
+++ b/src/network/websockets/server/ws-mock.ts
@@ -24,6 +24,7 @@ export function makeWsMock() {
             onClientMessage = cb as any;
             return;
           }
+          if (event === "close") return;
           throw new Error(`event ${event} not implemented`);
         },
         readyState: 1,


### PR DESCRIPTION
Two minor changes to improve memory cleaning. Detects disconnected clients and removes event listeners for closed sockets.