### PR TITLE
Refresh/expire authentication

### DIFF
--- a/src/network/websockets/server/index.ts
+++ b/src/network/websockets/server/index.ts
@@ -63,6 +63,9 @@ export function runWebsocketServer<AuthDetails>(params: Params<AuthDetails>) {
       );
     };
 
+    const reEvaluateToken = setInterval(evaluateToken, 5 * 60000);
+    socket.on("close", () => clearInterval(reEvaluateToken));
+
     const send = (obj: {}) => {
       if (socket.readyState !== 1) return;
       socket.send(JSON.stringify(obj));

--- a/src/network/websockets/server/types.ts
+++ b/src/network/websockets/server/types.ts
@@ -25,6 +25,7 @@ export type Params<AuthDetails> = {
       kind: string;
       id: string;
     }) => boolean;
+    // parseToken will be called multiple times over the course of one socket lifetime to refresh the permissions periodically
     parseToken: (
       token: string,
       params: {

--- a/src/network/websockets/server/ws-mock.ts
+++ b/src/network/websockets/server/ws-mock.ts
@@ -24,6 +24,7 @@ export function makeWsMock() {
             onClientMessage = cb as any;
             return;
           }
+          if (event === "close") return;
           throw new Error(`event ${event} not implemented`);
         },
         readyState: 1,


### PR DESCRIPTION
The core of the PR are these two lines:

```ts
const reEvaluateToken = setInterval(evaluateToken, 5 * 60000);
socket.on("close", () => clearInterval(reEvaluateToken));
```

So every 5 minutes we re-run the parseToken function. This means we’ll catch expired tokens, we’ll refresh the permissions, all without additional logic in the backend code.

- [x] Target branch temporary