### PR TITLE
feat: add kind arg to encode/decode interface

### DIFF
--- a/src/network/websockets/index.ts
+++ b/src/network/websockets/index.ts
@@ -64,16 +64,16 @@ export function makeWsProtocolAdapter(
           if (msg.result === "success")
             onPushResult(msg.pushId, {
               newRevision: msg.newRevision,
-              newValue: serialization.decode(msg.newValue)
+              newValue: serialization.decode(msg.newValue, msg.kind)
             });
           else onPushResult(msg.pushId, msg.result);
         },
-        update: (msg: any) =>
+        update: ({ id, kind, revision, value }: any) =>
           onChange({
-            kind: msg.kind,
-            id: msg.id,
-            revision: msg.revision,
-            value: serialization.decode(msg.value)
+            kind,
+            id,
+            revision,
+            value: serialization.decode(value, kind)
           })
       };
       socket.onmessage = function(event) {
@@ -100,7 +100,7 @@ export function makeWsProtocolAdapter(
             id,
             pushId,
             lastSeenRevision,
-            value: serialization.encode(value)
+            value: serialization.encode(value, kind)
           });
         }
       };

--- a/src/network/websockets/index.ts
+++ b/src/network/websockets/index.ts
@@ -60,20 +60,27 @@ export function makeWsProtocolAdapter(
           onError(new Error(msg.message));
         },
         pong: () => {},
-        pushResult: (msg: any) => {
-          if (msg.result === "success")
-            onPushResult(msg.pushId, {
-              newRevision: msg.newRevision,
-              newValue: serialization.decode(msg.newValue, msg.kind)
+        pushResult: ({
+          id,
+          kind,
+          newRevision,
+          newValue,
+          pushId,
+          result
+        }: any) => {
+          if (result === "success")
+            onPushResult(pushId, {
+              newRevision: newRevision,
+              newValue: serialization.decode(newValue, { id, kind })
             });
-          else onPushResult(msg.pushId, msg.result);
+          else onPushResult(pushId, result);
         },
         update: ({ id, kind, revision, value }: any) =>
           onChange({
             kind,
             id,
             revision,
-            value: serialization.decode(value, kind)
+            value: serialization.decode(value, { id, kind })
           })
       };
       socket.onmessage = function(event) {
@@ -100,7 +107,7 @@ export function makeWsProtocolAdapter(
             id,
             pushId,
             lastSeenRevision,
-            value: serialization.encode(value, kind)
+            value: serialization.encode(value, { id, kind: String(kind) })
           });
         }
       };

--- a/src/network/websockets/serialization.ts
+++ b/src/network/websockets/serialization.ts
@@ -1,6 +1,6 @@
 export type Serialization = {
-  encode: (value: unknown) => string;
-  decode: (string: string) => unknown;
+  encode: (value: unknown, kind: any) => string;
+  decode: (string: string, kind: any) => unknown;
 };
 
 export const jsonSerialization: Serialization = {

--- a/src/network/websockets/serialization.ts
+++ b/src/network/websockets/serialization.ts
@@ -1,6 +1,11 @@
+export type SerializationContext = {
+  id: string;
+  kind: string;
+};
+
 export type Serialization = {
-  encode: (value: unknown, kind: any) => string;
-  decode: (string: string, kind: any) => unknown;
+  encode: (value: unknown, context: SerializationContext) => string;
+  decode: (string: string, context: SerializationContext) => unknown;
 };
 
 export const jsonSerialization: Serialization = {

--- a/src/network/websockets/server/index.ts
+++ b/src/network/websockets/server/index.ts
@@ -119,7 +119,7 @@ export function runWebsocketServer<AuthDetails>(params: Params<AuthDetails>) {
           kind,
           lastSeenRevision,
           id,
-          value: serialization.decode(value, kind),
+          value: serialization.decode(value, { kind, id }),
           close: () => socket.terminate()
         })
           .then(function(result) {
@@ -132,10 +132,12 @@ export function runWebsocketServer<AuthDetails>(params: Params<AuthDetails>) {
             else
               send({
                 action: "pushResult",
+                id,
+                kind,
                 pushId: msg.pushId,
                 result: "success",
                 newRevision: result.newRevision,
-                newValue: serialization.encode(result.newValue, kind)
+                newValue: serialization.encode(result.newValue, { id, kind })
               });
           })
           .catch(function(err) {
@@ -168,7 +170,7 @@ export function runWebsocketServer<AuthDetails>(params: Params<AuthDetails>) {
               id,
               kind,
               revision: v.revision,
-              value: serialization.encode(v.value, kind)
+              value: serialization.encode(v.value, { id, kind })
             });
           }
         );

--- a/src/network/websockets/server/index.ts
+++ b/src/network/websockets/server/index.ts
@@ -119,7 +119,7 @@ export function runWebsocketServer<AuthDetails>(params: Params<AuthDetails>) {
           kind,
           lastSeenRevision,
           id,
-          value: serialization.decode(value),
+          value: serialization.decode(value, kind),
           close: () => socket.terminate()
         })
           .then(function(result) {
@@ -135,7 +135,7 @@ export function runWebsocketServer<AuthDetails>(params: Params<AuthDetails>) {
                 pushId: msg.pushId,
                 result: "success",
                 newRevision: result.newRevision,
-                newValue: serialization.encode(result.newValue)
+                newValue: serialization.encode(result.newValue, kind)
               });
           })
           .catch(function(err) {
@@ -168,7 +168,7 @@ export function runWebsocketServer<AuthDetails>(params: Params<AuthDetails>) {
               id,
               kind,
               revision: v.revision,
-              value: serialization.encode(v.value)
+              value: serialization.encode(v.value, kind)
             });
           }
         );


### PR DESCRIPTION
In the case of using specialized schema validation/encoding/decoding we
would like to have some context on the data being passed to
serialization functions which would allow us to make a judgement on
which specialized schema [validator|decoder|encoder] to use.

This is a non-breaking change.