### PR TITLE
useMultipleData

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ return (
     />
   </div>
 );
+
+// Prefer multiple useData calls above, but when the data you need to fetch is dynamic in its length, useMultipleData can help:
+const [data, update] = useMultipleData({ tasks: ["1", "3"], jobs: ["2"] });
+console.log(data.tasks["3"], data.jobs["2"]);
+update("tasks", "3", prev => ({ ...prev, title: "new title" }));
 ```
 
 A preview of how you access the information about the status of the synchronization, like whether the user is offline and whether any changes are not saved yet:

--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ return (
 );
 
 // Prefer multiple useData calls above, but when the data you need to fetch is dynamic in its length, useMultipleData can help:
+const [tasks, update] = useMultipleData("tasks", ["1", "3"]);
+console.log(tasks["1"], tasks["3"]);
+update("3", prev => ({ ...prev, title: "new title" }));
+
+// Even more advanced use for multiple kinds:
 const [data, update] = useMultipleData({ tasks: ["1", "3"], jobs: ["2"] });
 console.log(data.tasks["3"], data.jobs["2"]);
 update("tasks", "3", prev => ({ ...prev, title: "new title" }));

--- a/README.md
+++ b/README.md
@@ -38,11 +38,6 @@ return (
 const [tasks, update] = useMultipleData("tasks", ["1", "3"]);
 console.log(tasks["1"], tasks["3"]);
 update("3", prev => ({ ...prev, title: "new title" }));
-
-// Even more advanced use for multiple kinds:
-const [data, update] = useMultipleData({ tasks: ["1", "3"], jobs: ["2"] });
-console.log(data.tasks["3"], data.jobs["2"]);
-update("tasks", "3", prev => ({ ...prev, title: "new title" }));
 ```
 
 A preview of how you access the information about the status of the synchronization, like whether the user is offline and whether any changes are not saved yet:

--- a/src/ui/react/hooks.ts
+++ b/src/ui/react/hooks.ts
@@ -61,7 +61,7 @@ export function makeHooks<Domain>(params: {
     };
   }
 
-  const useMultipleData = function<K extends keyof Domain>(
+  const useMultipleDataImplementation = function<K extends keyof Domain>(
     definition: { [k in K]: string[] }
   ): [
     { [k in K]: { [id: string]: Domain[k] } } | "loading",
@@ -119,6 +119,39 @@ export function makeHooks<Domain>(params: {
     ];
   };
 
+  function useMultipleData<K extends keyof Domain>(
+    kind: K,
+    ids: string[]
+  ): [
+    { [id: string]: Domain[K] } | "loading",
+    (id: string, delta: (prev: Domain[K]) => Domain[K]) => void
+  ];
+  function useMultipleData<K extends keyof Domain>(
+    definition: { [k in K]: string[] }
+  ): [
+    { [k in K]: { [id: string]: Domain[k] } } | "loading",
+    MassUpdater<Domain, K>
+  ];
+  function useMultipleData<K extends keyof Domain>(
+    kindOrDefinition: K | { [k in K]: string[] },
+    ids?: string[]
+  ) {
+    if (ids) {
+      const kind = kindOrDefinition as K;
+      const definition: { [k in keyof Domain]: string[] } = {
+        [kind]: ids
+      } as any;
+      const [data, update] = useMultipleDataImplementation<K>(definition);
+      return [
+        data === "loading" ? "loading" : data[kind],
+        (id: string, delta: (prev: Domain[K]) => Domain[K]) =>
+          update(kind, id, delta)
+      ];
+    }
+    const definition = kindOrDefinition as { [k in K]: string[] };
+    return useMultipleDataImplementation(definition);
+  }
+
   return {
     useConnectivity: () => {
       const db = useTryDB();
@@ -151,7 +184,7 @@ export function makeHooks<Domain>(params: {
     ): Changer<Domain[K]> {
       const [data, update] = useMultipleData<K>({
         [kind]: [id]
-      } as any);
+      } as { [k in K]: string[] });
       return [
         data === "loading" ? "loading" : data[kind][id],
         makeUpdater(update, kind, id)

--- a/src/ui/react/use-multiple-data.test.ts
+++ b/src/ui/react/use-multiple-data.test.ts
@@ -1,0 +1,37 @@
+import test from "ava";
+
+import { configure } from "./configure";
+import { makeReactMock, makeWindowMock, networkMock } from "./mocks";
+
+test("useMultipleData sanity", t => {
+  const react = makeReactMock();
+  const { create, useMultipleData } = configure({
+    data: {
+      tasks: {
+        "1": { revision: "1", value: "Buy milk" },
+        "2": { revision: "1", value: "Fix roof" }
+      },
+      projects: {
+        "1": { revision: "1", value: { size: "big" } }
+      },
+      unused: { "0": { revision: "1", value: "Unused" } }
+    },
+    React: react
+  });
+  const { db } = create({
+    network: networkMock,
+    onError: err => t.fail(err.message),
+    window: makeWindowMock()
+  });
+  react._setContextValue(db);
+  const [data, update] = useMultipleData({
+    tasks: ["1", "2"],
+    projects: ["1"]
+  });
+  if (data === "loading") return t.fail("Expected data to not be loading");
+  t.is(data.tasks["1"], "Buy milk");
+  t.is(data.tasks["2"], "Fix roof");
+  t.is(data.projects["1"].size, "big");
+  t.is((data as any).unused, undefined);
+  t.is(typeof update, "function");
+});

--- a/src/ui/react/use-multiple-data.test.ts
+++ b/src/ui/react/use-multiple-data.test.ts
@@ -24,6 +24,13 @@ test("useMultipleData sanity", t => {
     window: makeWindowMock()
   });
   react._setContextValue(db);
+
+  const [tasks, updateTask] = useMultipleData("tasks", ["1", "2"]);
+  if (tasks === "loading") return t.fail("Expected tasks to not be loading");
+  t.is(tasks["1"], "Buy milk");
+  t.is(tasks["2"], "Fix roof");
+  t.is(typeof updateTask, "function");
+
   const [data, update] = useMultipleData({
     tasks: ["1", "2"],
     projects: ["1"]

--- a/src/ui/react/use-multiple-data.test.ts
+++ b/src/ui/react/use-multiple-data.test.ts
@@ -30,15 +30,4 @@ test("useMultipleData sanity", t => {
   t.is(tasks["1"], "Buy milk");
   t.is(tasks["2"], "Fix roof");
   t.is(typeof updateTask, "function");
-
-  const [data, update] = useMultipleData({
-    tasks: ["1", "2"],
-    projects: ["1"]
-  });
-  if (data === "loading") return t.fail("Expected data to not be loading");
-  t.is(data.tasks["1"], "Buy milk");
-  t.is(data.tasks["2"], "Fix roof");
-  t.is(data.projects["1"].size, "big");
-  t.is((data as any).unused, undefined);
-  t.is(typeof update, "function");
 });


### PR DESCRIPTION
This allows to use a single hook to retrieve or update multiple Oncilla atoms. See the usage in README.

This takes what we had as useData and modifies all individual work pieces to iterate over multiple data atoms.