### PR TITLE
network/websockets: restart ping on reconnect

### DIFF
--- a/src/network/websockets/index.ts
+++ b/src/network/websockets/index.ts
@@ -45,6 +45,7 @@ export function makeWsProtocolAdapter(
     }) {
       socket.onopen = () => {
         onConnectivityChange("online");
+        restartPingMachine();
         messagesOnEveryReconnect.forEach(send);
       };
       socket.onclose = () => onConnectivityChange("offline");


### PR DESCRIPTION
If a connection dies and we restart it,
our ping machinery would not restart with it,
leading to more connection timeouts going forward.